### PR TITLE
feat: allow single games for configure CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ To generate such a configuration you call `uv run xega configure`.
 uv run xega configure
 # Generate a configuration with a simple game played by gpt-4.1 and o3
 uv run xega configure --model gpt-4.1 --model o3
-# Generate a configuration from games defined in a directory
-uv run xega configure --game-dir ./games
+# Generate a configuration from specific game files and/or directories
+uv run xega configure --game-path ./games/Condense.xega --game-path ./games
 # See more CLI configuration options
 uv run xega configure --help
 ```

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,7 +10,7 @@ from click.testing import CliRunner
 from xega.cli.configure import (
     add_player_to_expanded_config,
     configure,
-    games_from_dir,
+    games_from_paths,
     remove_player_from_expanded_config,
 )
 from xega.cli.run import check_version
@@ -217,34 +217,36 @@ class TestConfigureCommands:
 class TestCLIPresentationIntegration:
     """Test CLI integration with presentation functions"""
 
-    def test_games_from_dir_comprehensive(self):
-        """Test games_from_dir with various presentation scenarios."""
-        with tempfile.TemporaryDirectory() as temp_dir:
+    def test_games_from_paths_comprehensive(self):
+        """Test games_from_paths with various presentation scenarios."""
+        with tempfile.TemporaryDirectory() as temp_dir_path:
+            temp_dir = Path(temp_dir_path)
             # Scenario 1: Game without presentation
-            simple_path = Path(temp_dir) / "simple.xega"
+            simple_path = temp_dir / "simple.xega"
             simple_path.write_text('assign(s="test")\nreveal(black, s)')
 
             # Scenario 2: Game with valid presentation
-            custom_path = Path(temp_dir) / "custom.xega"
+            custom_path = temp_dir / "custom.xega"
             custom_path.write_text('assign(s="custom")\nreveal(black, s)')
-            custom_pres_path = Path(temp_dir) / "custom_presentation.py"
+            custom_pres_path = temp_dir / "custom_presentation.py"
             custom_pres_path.write_text("""def present(state, history):
     return "Custom presentation"
 """)
 
             # Scenario 3: Game with non-standard presentation (warnings)
-            warning_path = Path(temp_dir) / "warning.xega"
+            warning_path = temp_dir / "warning.xega"
             warning_path.write_text('assign(s="warning")')
-            warning_pres_path = Path(temp_dir) / "warning_presentation.py"
+            warning_pres_path = temp_dir / "warning_presentation.py"
             warning_pres_path.write_text("""def present(game_state, events):  # Non-standard names
     return "Works with warnings"
 """)
 
             # Scenario 4: Another game without presentation to test mixed scenario
-            another_path = Path(temp_dir) / "another.xega"
+            another_path = temp_dir / "another.xega"
             another_path.write_text('assign(s="another")')
 
-            games = games_from_dir(temp_dir)
+            # Test that duplicate games are not added
+            games = games_from_paths([simple_path, temp_dir])
             assert len(games) == 4
 
             # Verify each game


### PR DESCRIPTION
Added a `--game-path` flag that allows to pass a single game or folder (repeatedly) in the `xega configure` CLI.

I kept `--game-dir` as an alias to `--game-path` for backwards compatibility, and to more explicitly show that directories are acceptable. I'm not sure if those are important though, and I'm happy to remove it (or for you to do it).

All tests pass, but I had to modify `test_games_from_dir_comprehensive`. I didn't add more tests for this, except that duplicate games are not added twice in the benchmark.

There are some mypy errors, but in unrelated parts of the codebase.