### PR TITLE
Emit events at start/end of rounds for ease of parsing event streams

### DIFF
--- a/src/xega/common/xega_event.py
+++ b/src/xega/common/xega_event.py
@@ -11,39 +11,54 @@ class TokenUsage(TypedDict):
 
 
 class BaseXegaEvent(TypedDict):
+    pass
+
+
+class LineXegaEvent(BaseXegaEvent):
     line: str
     line_num: int
     player: str
 
 
-class ElicitRequestEvent(BaseXegaEvent):
+class ElicitRequestEvent(LineXegaEvent):
     type: Literal["elicit_request"]
     var_name: str
     max_len: int
     registers: dict[str, XString]
 
 
-class ElicitResponseEvent(BaseXegaEvent):
+class ElicitResponseEvent(LineXegaEvent):
     type: Literal["elicit_response"]
     response: str
     token_usage: TokenUsage
 
 
-class RevealEvent(BaseXegaEvent):
+class RevealEvent(LineXegaEvent):
     type: Literal["reveal"]
     # Map of variable names to their values.
     values: dict[str, XString]
 
 
-class RewardEvent(BaseXegaEvent):
+class RewardEvent(LineXegaEvent):
     type: Literal["reward"]
     value: TokenXentList
 
 
-class FailedEnsureEvent(BaseXegaEvent):
+class FailedEnsureEvent(LineXegaEvent):
     type: Literal["failed_ensure"]
     ensure_results: list[bool]
     beacon: str
+
+
+class RoundStartedEvent(BaseXegaEvent):
+    type: Literal["round_started"]
+    round_index: int
+
+
+class RoundFinishedEvent(BaseXegaEvent):
+    type: Literal["round_finished"]
+    round_index: int
+    best_score: float
 
 
 XegaEvent = (
@@ -52,4 +67,6 @@ XegaEvent = (
     | RevealEvent
     | RewardEvent
     | FailedEnsureEvent
+    | RoundStartedEvent
+    | RoundFinishedEvent
 )

--- a/src/xega/common/xega_event.py
+++ b/src/xega/common/xega_event.py
@@ -11,40 +11,36 @@ class TokenUsage(TypedDict):
 
 
 class BaseXegaEvent(TypedDict):
-    pass
-
-
-class LineXegaEvent(BaseXegaEvent):
     line: str
     line_num: int
     player: str
 
 
-class ElicitRequestEvent(LineXegaEvent):
+class ElicitRequestEvent(BaseXegaEvent):
     type: Literal["elicit_request"]
     var_name: str
     max_len: int
     registers: dict[str, XString]
 
 
-class ElicitResponseEvent(LineXegaEvent):
+class ElicitResponseEvent(BaseXegaEvent):
     type: Literal["elicit_response"]
     response: str
     token_usage: TokenUsage
 
 
-class RevealEvent(LineXegaEvent):
+class RevealEvent(BaseXegaEvent):
     type: Literal["reveal"]
     # Map of variable names to their values.
     values: dict[str, XString]
 
 
-class RewardEvent(LineXegaEvent):
+class RewardEvent(BaseXegaEvent):
     type: Literal["reward"]
     value: TokenXentList
 
 
-class FailedEnsureEvent(LineXegaEvent):
+class FailedEnsureEvent(BaseXegaEvent):
     type: Literal["failed_ensure"]
     ensure_results: list[bool]
     beacon: str
@@ -58,7 +54,6 @@ class RoundStartedEvent(BaseXegaEvent):
 class RoundFinishedEvent(BaseXegaEvent):
     type: Literal["round_finished"]
     round_index: int
-    best_score: float
 
 
 XegaEvent = (

--- a/src/xega/runtime/execution.py
+++ b/src/xega/runtime/execution.py
@@ -11,6 +11,7 @@ from xega.common.errors import (
     XegaSyntaxError,
 )
 from xega.common.x_flag import XFlag
+from xega.common.xega_event import RoundFinishedEvent, RoundStartedEvent
 from xega.runtime.runtime import XegaRuntime
 
 
@@ -38,7 +39,7 @@ async def play_game(
     round_results: list[GameMapRoundResult] = []
 
     while rounds_played < num_rounds:
-        result = await play_single_game(lines, xrt)
+        result = await play_single_game(lines, xrt, rounds_played)
         if result is None:
             return []  # TODO what to do here?
         rounds_played += 1
@@ -51,8 +52,13 @@ async def play_game(
 
 # TODO need to clean up error handling / none return here
 async def play_single_game(
-    lines: list[str], xrt: XegaRuntime
+    lines: list[str],
+    xrt: XegaRuntime,
+    rounds_played: int,
 ) -> GameMapRoundResult | None:
+    start_event = RoundStartedEvent(type="round_started", round_index=rounds_played)
+    await xrt.send_event(xrt.player, start_event)
+
     line_index = 0
 
     while line_index < len(lines):
@@ -72,6 +78,11 @@ async def play_single_game(
                 raise XegaInternalError(
                     f"Invalid line number {line_index} returned by instruction"
                 )
+
+    finish_event = RoundFinishedEvent(
+        type="round_finished", round_index=rounds_played, best_score=xrt.score
+    )
+    await xrt.send_event(xrt.player, finish_event)
 
     logging.info("Game round completed successfully")
     results = xrt.get_results_and_reset()

--- a/src/xega/runtime/execution.py
+++ b/src/xega/runtime/execution.py
@@ -56,7 +56,13 @@ async def play_single_game(
     xrt: XegaRuntime,
     rounds_played: int,
 ) -> GameMapRoundResult | None:
-    start_event = RoundStartedEvent(type="round_started", round_index=rounds_played)
+    start_event = RoundStartedEvent(
+        type="round_started",
+        round_index=rounds_played,
+        line=lines[0],
+        line_num=1,
+        player=xrt.player.name,
+    )
     await xrt.send_event(xrt.player, start_event)
 
     line_index = 0
@@ -80,7 +86,11 @@ async def play_single_game(
                 )
 
     finish_event = RoundFinishedEvent(
-        type="round_finished", round_index=rounds_played, best_score=xrt.score
+        type="round_finished",
+        round_index=rounds_played,
+        line=lines[-1],
+        line_num=len(lines) - 1,
+        player=xrt.player.name,
     )
     await xrt.send_event(xrt.player, finish_event)
 

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -1006,9 +1006,9 @@ class TestCombinedOperations:
 
         player = xrt.player
         # Should have received two reveals + elicit + elicit response
-        assert len(player.event_history) == 4
-        assert "Please enter a word" in str(player.event_history[0])
-        assert "mocked_move" in str(player.event_history[3])
+        assert len(player.event_history) == 6
+        assert "Please enter a word" in str(player.event_history[1])
+        assert "mocked_move" in str(player.event_history[4])
 
     @pytest.mark.asyncio
     async def test_elicit_registers(self, xrt):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -178,7 +178,17 @@ def test_benchmark_structure(shared_benchmark_results):
 
     game2_iteration = game2_result["round_results"][0]
     event_types = [e["type"] for e in game2_iteration["history"]]
-    assert event_types == expected_types * 2
+    expected_types = [
+        "round_started",
+        "reveal",
+        "elicit_request",
+        "elicit_response",
+        "reward",
+        "reveal",
+        "reward",
+        "round_finished",
+    ]
+    assert event_types == expected_types
 
 
 @pytest.mark.integration

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -160,16 +160,25 @@ def test_benchmark_structure(shared_benchmark_results):
 
     game1_iteration = game1_result["round_results"][0]
     assert game1_result["score"] == game1_iteration["score"]
-    assert (
-        len(game1_iteration["history"]) == 5
-    )  # reveal, elicit(req), elicit(resp), reward, reward
+    event_types = [e["type"] for e in game1_iteration["history"]]
+    expected_types = [
+        "round_started",
+        "reveal",
+        "elicit_request",
+        "elicit_response",
+        "reward",
+        "reward",
+        "round_finished",
+    ]
+    assert event_types == expected_types
 
     # Test Game 2 (multi-step)
     game2_result = game_results[1]
     assert len(game2_result["round_results"]) == 1  # Single round
 
     game2_iteration = game2_result["round_results"][0]
-    assert len(game2_iteration["history"]) > 5  # More steps than game 1
+    event_types = [e["type"] for e in game2_iteration["history"]]
+    assert event_types == expected_types * 2
 
 
 @pytest.mark.integration

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1632,7 +1632,7 @@ elicit(black, x, 5)""",
 
 class TestRoundBoundaryEvents:
     @pytest.mark.asyncio
-    async def test_round_events_emitted_once_at_boundaries(self, xrt):
+    async def test_round_start_and_finish_events(self, xrt):
         game_code = """
         assign(s='hello')
         reveal(black, s)
@@ -1655,11 +1655,8 @@ class TestRoundBoundaryEvents:
         finish_event = history[-1]
 
         # Round index present and equal
-        assert isinstance(start_event["round_index"], int)
-        assert isinstance(finish_event["round_index"], int)
         assert start_event["round_index"] == finish_event["round_index"] == 0
 
-        # Finish payload contains registers and best_score
-        assert "best_score" in finish_event and isinstance(
-            finish_event["best_score"], float
-        )
+        # Check that players are strings
+        for event in history:
+            assert isinstance(event["player"], str)


### PR DESCRIPTION
Notes:
1. I updated some of the test to take into account the new events, but I'm not sure all the code runs properly. For instance, I didn't check if the presentation functions of every game still work. That would be a useful test to add though.
2. I didn't include line, line_no, and player on the new events because they don't quite make sense, so I had to make a new inheritance branch under BaseXegaEvent
3. Uncertainty: does the runtime currently support multiple players? Otherwise the events need to be sent to every player, which I don't do.